### PR TITLE
bblayers.conf.sample: add meta-perl

### DIFF
--- a/layers/meta-balena-5x-owa/conf/samples/bblayers.conf.sample
+++ b/layers/meta-balena-5x-owa/conf/samples/bblayers.conf.sample
@@ -10,6 +10,7 @@ BBLAYERS ?= " \
     ${TOPDIR}/../layers/poky/meta-poky \
     ${TOPDIR}/../layers/meta-openembedded/meta-oe \
     ${TOPDIR}/../layers/meta-openembedded/meta-python \
+    ${TOPDIR}/../layers/meta-openembedded/meta-perl \
     ${TOPDIR}/../layers/meta-freescale \
     ${TOPDIR}/../layers/meta-freescale-3rdparty \
     ${TOPDIR}/../layers/meta-freescale-distro \


### PR DESCRIPTION
Perl is required for building efitools used for
EFI boot entry configuration and secure boot,

Changelog-entry: add meta-perl to bblayers.conf
Signed-off-by: Alex Gonzalez <alexg@balena.io>
