### PR TITLE
<owa5X log & meta-owasys> Changed logo and updated meta-owasys.

### DIFF
--- a/layers/meta-balena-5x-owa/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-5x-owa/recipes-core/images/balena-image.inc
@@ -38,13 +38,14 @@ IMAGE_INSTALL:append = " \
                         linux-firmware-owasys \
                         wpa-supplicant \
                         udev-rules-owasys \
-                        system-maintenance-service \
                         rtc-tools \
                         quectel-cm \
                         switch-gsm \
                         st32-firmware \
                         chatscripts \
                         issue-owa \
+                        sync-time-rtc \
+                        owasys-hw-sn-file \
 "
 
 deltask do_packagedata


### PR DESCRIPTION
System_maintenance service presents problems working with BalenaOS policy. As a consequence it's been removed.
Also we are updating owa5X logo and upgrading our meta-owasys.

Changelog-entry: Updated meta-owasys and removed system-maintenance.
Signed-off-by: Alvaro Guzman <alvaro.