### PR TITLE
<meta-balena-5x-owa> Removed config

### DIFF
--- a/layers/meta-balena-5x-owa/recipes-bsp/u-boot/files/0001-Removed_cmd_saveenv_and_offset_redundant.patch
+++ b/layers/meta-balena-5x-owa/recipes-bsp/u-boot/files/0001-Removed_cmd_saveenv_and_offset_redundant.patch
@@ -1,0 +1,36 @@
+From e57d394510e1f893ead1b9fab3c6f392bf22431d Mon Sep 17 00:00:00 2001
+From: Alvaro Guzman <alvaro.guzman@owasys.com>
+Date: Mon, 20 Mar 2023 10:38:35 +0100
+Subject: [PATCH] Removed_cmd_saveenv_and_offset_redundant
+
+---
+ configs/imx8mp_owa5x_defconfig | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/configs/imx8mp_owa5x_defconfig b/configs/imx8mp_owa5x_defconfig
+index 6c82df9b72..957c9a6e34 100644
+--- a/configs/imx8mp_owa5x_defconfig
++++ b/configs/imx8mp_owa5x_defconfig
+@@ -42,6 +42,7 @@ CONFIG_CMD_IMPORTENV=y
+ CONFIG_CMD_PART=y
+ CONFIG_CMD_FS_UUID=y
+ CONFIG_CMD_ERASEENV=y
++CONFIG_CMD_SAVEENV=n
+ CONFIG_CMD_CRC32 is not set
+ # CONFIG_BOOTM_NETBSD is not set
+ CONFIG_CMD_CLK=y
+@@ -71,9 +72,9 @@ CONFIG_ENV_SIZE=0x80000
+ CONFIG_ENV_OFFSET=0x200000
+ CONFIG_ENV_SECT_SIZE=0x40000
+ CONFIG_SYS_ENV_SECT_SIZE=0x40000
+-CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
++CONFIG_SYS_REDUNDAND_ENVIRONMENT=n
+ #CONFIG_ENV_ADDR_REDUND=0x01100000
+-CONFIG_ENV_OFFSET_REDUND=0x300000
++#CONFIG_ENV_OFFSET_REDUND=0x300000
+ CONFIG_ENV_SIZE_REDUND=0x80000
+ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+ #CONFIG_ENV_VARS_UBOOT_RUNTIME=y
+-- 
+2.25.1
+

--- a/layers/meta-balena-5x-owa/recipes-bsp/u-boot/u-boot-owasys.bbappend
+++ b/layers/meta-balena-5x-owa/recipes-bsp/u-boot/u-boot-owasys.bbappend
@@ -8,7 +8,10 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 # resin-u-boot class patch is rebased
 SRC_URI:remove = " file://resin-specific-env-integration-kconfig.patch "
 
-SRC_URI:append:owa5x = " file://Balena-integration-u-boot-env-configs.patch "
+SRC_URI:append:owa5x = " \
+                      file://Balena-integration-u-boot-env-configs.patch \
+                      file://0001-Removed_cmd_saveenv_and_offset_redundant.patch \
+ "
 
 SRC_URI += "file://fw_env.config"
 


### PR DESCRIPTION
According to Florin Ionut this u-boot config CONFIG_ENV_OFFSET_REDUND, must be removed in order to obtain a new release image, because there is a problem with the compilation.

Changelog-entry: u-boot CONFIG_ENV_OFFSET_REDUND removed