### PR TITLE
<meta-balena-5x-owa> Fixed u-boot resin vars

### DIFF
--- a/layers/meta-balena-5x-owa/recipes-bsp/u-boot/files/0002-Fixed-set-balena-env-variables.patch
+++ b/layers/meta-balena-5x-owa/recipes-bsp/u-boot/files/0002-Fixed-set-balena-env-variables.patch
@@ -1,0 +1,48 @@
+From ed7dab1759e0c64a6543598da2da71bf51291b9d Mon Sep 17 00:00:00 2001
+From: Alvaro Guzman <alvaro.guzman@owasys.com>
+Date: Tue, 21 Mar 2023 17:21:52 +0100
+Subject: [PATCH] Fixed set balena env variables
+
+---
+ include/configs/imx8mp_owa5x.h | 20 ++++++++++++++++----
+ 1 file changed, 16 insertions(+), 4 deletions(-)
+
+diff --git a/include/configs/imx8mp_owa5x.h b/include/configs/imx8mp_owa5x.h
+index 4ca024ed22..ba6b885e24 100644
+--- a/include/configs/imx8mp_owa5x.h
++++ b/include/configs/imx8mp_owa5x.h
+@@ -193,15 +193,27 @@
+ 	"boot_fit=no\0" \
+ 	"mtdids="	CONFIG_MTDIDS_DEFAULT	"\0" \
+ 	"mtdparts=" CONFIG_MTDPARTS_DEFAULT "\0" \
+-	"console=ttymxc0,115200 earlycon=ec_imx6q,0x30860000,115200\0" \
++	"console=ttymxc0,115200\0" \
+ 	"mmcdev=2\0" \
+ 	"mmcpart=1\0" \
+ 	"mmcroot=" CONFIG_MMCROOT " rootwait quiet rw\0" \
+ 	"mmcautodetect=yes\0" \
+ 	"zip_addr=0x70480000\0" \
+-	"mmcargs=setenv bootargs console=${console} root=${mmcroot} rootfstype=ext4\0" \
+-	"BOOT_CMD_BALENA=run mmcargs; fatload mmc ${mmcdev}:1 ${zip_addr} ${image}; fatload mmc ${mmcdev}:1 ${fdt_addr} ${fdt_file}; unzip ${zip_addr} ${loadaddr}; "\
+-	"booti ${loadaddr} - ${fdt_addr};\0" \
++	"mmcargs=setenv bootargs ${jh_clk} console=${console} ${resin_kernel_root} ${os_cmdline}\0" \
++	"set_up_balena_env_vars=setenv resin_kernel_load_addr ${loadaddr};" \
++		"run resin_set_kernel_root; run set_os_cmdline; " \
++		"setenv usbdev ${resin_dev_index};" \
++		"setenv usbbootpart ${resin_boot_part};" \
++		"setenv mmcdev ${resin_dev_index};" \
++		"setenv mmcbootpart ${resin_boot_part};\0" \
++	"balena_load_kernel=fatload mmc ${mmcdev}:${mmcbootpart} ${zip_addr} ${image}\0 " \
++	"balena_load_fdt=fatload mmc ${mmcdev}:${mmcbootpart} ${fdt_addr} ${fdt_file}\0 " \
++	"BOOT_CMD_BALENA=run set_up_balena_env_vars; " \
++		"run mmcargs; " \ 
++		"run balena_load_kernel; " \
++		"run balena_load_fdt; " \
++		"unzip ${zip_addr} ${loadaddr}; " \
++		"booti ${loadaddr} - ${fdt_addr};\0" \
+ 	"startmmcboot=echo Booting from mmc ...; " \
+ 		"run mmcargs; " \
+ 		"if test ${boot_fit} = yes || test ${boot_fit} = try; then " \
+-- 
+2.25.1
+

--- a/layers/meta-balena-5x-owa/recipes-bsp/u-boot/u-boot-owasys.bbappend
+++ b/layers/meta-balena-5x-owa/recipes-bsp/u-boot/u-boot-owasys.bbappend
@@ -11,6 +11,7 @@ SRC_URI:remove = " file://resin-specific-env-integration-kconfig.patch "
 SRC_URI:append:owa5x = " \
                       file://Balena-integration-u-boot-env-configs.patch \
                       file://0001-Removed_cmd_saveenv_and_offset_redundant.patch \
+                      file://0002-Fixed-set-balena-env-variables.patch \
  "
 
 SRC_URI += "file://fw_env.config"

--- a/layers/meta-balena-5x-owa/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-5x-owa/recipes-core/images/balena-image.inc
@@ -9,7 +9,7 @@ IMAGE_CMD:balenaos-img:append () {
     dd if=${DEPLOY_DIR_IMAGE}/${MACHINE}-flash.bin of=${BALENA_RAW_IMG} conv=notrunc seek=32 bs=1K
 }
 
-BALENA_BOOT_SIZE = "50000"
+BALENA_BOOT_SIZE = "70000"
 IMAGE_ROOTFS_SIZE = "409600"
 
 IMAGE_INSTALL:remove = "kernel-image"

--- a/layers/meta-balena-5x-owa/recipes-support/hostapp-update-hooks/files/99-flash-bootloader
+++ b/layers/meta-balena-5x-owa/recipes-support/hostapp-update-hooks/files/99-flash-bootloader
@@ -2,19 +2,15 @@
 
 #
 # Script used by hostapps updater to flash bootloader onto internal media
-# Owa5x internal memory architecture is composed by a NAND and eMMC. HW connections enforces us to boot from the NAND as eMMC
-# is located at the secondary SDHC interface of the imx8, which is not bootable. 
-# The tool to update the flash.bin in a NAND device is a program called kobs, which is used like this: 
-# $kobs-ng init -v --chip_0_device_path=/dev/mtd0 /tmp/flash.bin
+#
 
 set -o errexit
 
 # machine specific data
 
 uboot_file="owa5x-flash.bin"
-# These variables below are not needed as we are flashing in a NAND which is a non-block device.
-# uboot_block_size=1024
-# uboot_seek_blocks=32
+uboot_block_size=1024
+uboot_seek_blocks=32
 
 device="/dev/mmcblk2boot0"
 
@@ -29,11 +25,8 @@ for i in $update_files; do
         update_size=$(ls -al /resin-boot/$current_update_file | awk '{print $5}')
         update_md5sum=$(md5sum /resin-boot/$current_update_file | awk '{print $1'})
 
-        # calculate number of bytes to skip when computing the checksum of the data we want to update (i.e. the data already written to $device)
-        let skip_bytes=$block_size*$seek_blocks
-
         # calculate md5sum of the data already written to $device, using $update_size bytes and skipping $skip_bytes from $device
-        existing_md5sum=$(dd if=$device skip=$skip_bytes bs=1 count=$update_size status=none | md5sum | awk '{print $1}')
+        existing_md5sum=$(dd if=$device bs=1 count=$update_size status=none | md5sum | awk '{print $1}')
 
         if [ ! "$existing_md5sum" = "$update_md5sum" ]; then
                 echo "Flashing $current_update_file to $device"


### PR DESCRIPTION
Fixed mnt-sysroot-active.service: Failed with result 'exit-code'. 
No kernel-root variable was passed to the kernel cmdline, which 
prevented symlinks to be created at /dev/disk/by-state/

Changelog-entry: mnt-sysroot-active fixed
Signed-off-by: Alvaro Guzman <alvaro.guzman@owasys.com>
