### PR TITLE
hostapp-update-hooks-flash-bootloader: fixed script error

### DIFF
--- a/layers/meta-balena-5x-owa/recipes-support/hostapp-update-hooks/files/99-flash-bootloader
+++ b/layers/meta-balena-5x-owa/recipes-support/hostapp-update-hooks/files/99-flash-bootloader
@@ -2,19 +2,15 @@
 
 #
 # Script used by hostapps updater to flash bootloader onto internal media
-# Owa5x internal memory architecture is composed by a NAND and eMMC. HW connections enforces us to boot from the NAND as eMMC
-# is located at the secondary SDHC interface of the imx8, which is not bootable. 
-# The tool to update the flash.bin in a NAND device is a program called kobs, which is used like this: 
-# $kobs-ng init -v --chip_0_device_path=/dev/mtd0 /tmp/flash.bin
+#
 
 set -o errexit
 
 # machine specific data
 
 uboot_file="owa5x-flash.bin"
-# These variables below are not needed as we are flashing in a NAND which is a non-block device.
-# uboot_block_size=1024
-# uboot_seek_blocks=32
+uboot_block_size=1024
+uboot_seek_blocks=32
 
 device="/dev/mmcblk2boot0"
 
@@ -30,7 +26,7 @@ for i in $update_files; do
         update_md5sum=$(md5sum /resin-boot/$current_update_file | awk '{print $1'})
 
         # calculate number of bytes to skip when computing the checksum of the data we want to update (i.e. the data already written to $device)
-        let skip_bytes=$block_size*$seek_blocks
+        let skip_bytes=$uboot_block_size*$uboot_seek_blocks
 
         # calculate md5sum of the data already written to $device, using $update_size bytes and skipping $skip_bytes from $device
         existing_md5sum=$(dd if=$device skip=$skip_bytes bs=1 count=$update_size status=none | md5sum | awk '{print $1}')


### PR DESCRIPTION
block_size and seek_blocks variables didn't exist
which caused a syntax error when running the hook. Instead uboot_block_size and uboot_seek_block are now used to compute the skipped bytes.

Changelog-entry: 99-flash-bootloader fixed
Signed-off-by: Alvaro Guzman alvaro.guzman@owasys.com