### PR TITLE
balena-image: increased boot partition size

### DIFF
--- a/layers/meta-balena-5x-owa/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-5x-owa/recipes-core/images/balena-image.inc
@@ -9,7 +9,7 @@ IMAGE_CMD:balenaos-img:append () {
     dd if=${DEPLOY_DIR_IMAGE}/${MACHINE}-flash.bin of=${BALENA_RAW_IMG} conv=notrunc seek=32 bs=1K
 }
 
-BALENA_BOOT_SIZE = "50000"
+BALENA_BOOT_SIZE = "70000"
 IMAGE_ROOTFS_SIZE = "409600"
 
 IMAGE_INSTALL:remove = "kernel-image"


### PR DESCRIPTION
When trying to perform a hostUpdateOS we came to the error:

_Boot files copy operations will fail with out of space error_

Increasing boot partition size fixes it.

Changelog-entry: no space left on boot partition fixed
Signed-off-by: Alvaro Guzman alvaro.guzman@owasys.com