### PR TITLE
balena-image: added systemd-extra-utils

### DIFF
--- a/layers/meta-balena-5x-owa/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-5x-owa/recipes-core/images/balena-image.inc
@@ -18,6 +18,7 @@ IMAGE_INSTALL:append = " \
                         imx-kobs \
                         net-tools \ 
                         inetutils \
+                        systemd-extra-utils \
                         iw \
                         iproute2 \
                         can-utils \


### PR DESCRIPTION
systemd-run was needed to perform balenaOS Update

Changelog-entry: balenaOS Update fixed
Signed-off-by: Alvaro Guzman alvaro.guzman@owasys.com