### PR TITLE
linux-owasys-owa5x: ensure apparmor is disabled

### DIFF
--- a/layers/meta-balena-5x-owa/recipes-kernel/linux/linux-owasys-owa5x.bbappend
+++ b/layers/meta-balena-5x-owa/recipes-kernel/linux/linux-owasys-owa5x.bbappend
@@ -1,13 +1,6 @@
 LICENSE = "CLOSED"
 
 inherit kernel-resin deploy
-#inherit kernel-resin
-
-# Fixes error: packages already installed
-# by kernel-image-initramfs
-#do_install:append() {
-#	rm ${D}/boot/Image.gz-5.10.72-1.0.7
-#}
 
 BALENA_CONFIGS:append = " nfsfs"
 BALENA_CONFIGS[nfsfs] = " \
@@ -19,14 +12,9 @@ BALENA_CONFIGS[nfsfs] = " \
     CONFIG_NFSD_V4=y \
 "
 
-
-#BALENA_CONFIGS[nfsfs] = " \
-#    CONFIG_NFS_FS=m \
-#    CONFIG_NFS_V2=m \
-#    CONFIG_NFS_V3=m \
-#    CONFIG_NFS_V4=m \
-#    CONFIG_NFSD_V3=y \
-#    CONFIG_NFSD_V4=y \
-#"
+BALENA_CONFIGS:append = " disable_apparmor"
+BALENA_CONFIGS[disable_apparmor] = " \
+    CONFIG_SECURITY_APPARMOR=n \
+"
 
 SCMVERSION="n"


### PR DESCRIPTION
Currently balenaOS disables DEFAULT_SECURITY_APPARMOR due to containers failing to start with missing dependencies.

Owasys BSP enables CONFIG_SECURITY_APPARMOR and the final result is apparmor enabled although disabled from meta-balena.

Changelog-entry: ensure apparmor is disabled
Signed-off-by: Alvaro Guzman alvaro.guzman@owasys.com