### PR TITLE
owa5x.coffee: add community field

### DIFF
--- a/owa5x.coffee
+++ b/owa5x.coffee
@@ -16,6 +16,7 @@ module.exports =
         name: 'owa5x'
         arch: 'aarch64'
         state: 'released'
+        community: true
  
         stateInstructions:
                 postProvisioning: postProvisioningInstructions


### PR DESCRIPTION
Added a supported by community field on
board description file owa5x.coffee
Although not currently used, it helps balena
identify community supported boards.

Changelog-entry: added community supported file
Signed-off-by: Alvaro Guzman alvaro.guzman@owasys.com