### PR TITLE
u-boot-owasys.bbappend: fixed reboot issue

### DIFF
--- a/layers/meta-balena-5x-owa/recipes-bsp/u-boot/files/0001-Fix-reboot-issue-upgrade-available-init-value-is-0.patch
+++ b/layers/meta-balena-5x-owa/recipes-bsp/u-boot/files/0001-Fix-reboot-issue-upgrade-available-init-value-is-0.patch
@@ -1,0 +1,25 @@
+From fe48b57945cc6d7dbe5014be8cd264da6f53fb37 Mon Sep 17 00:00:00 2001
+From: Alvaro Guzman <alvaro.guzman@owasys.com>
+Date: Mon, 24 Apr 2023 12:06:20 +0200
+Subject: [PATCH] Fixing reboot issue upgrade available init value is 0
+
+---
+ include/configs/imx8mp_owa5x.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/configs/imx8mp_owa5x.h b/include/configs/imx8mp_owa5x.h
+index d10bf19259..e49eca6047 100644
+--- a/include/configs/imx8mp_owa5x.h
++++ b/include/configs/imx8mp_owa5x.h
+@@ -189,7 +189,7 @@
+ 	"fdt_addr=0x88000000\0"			\
+ 	"fdt_high=0xffffffffffffffff\0" \
+ 	"fdt_file=" CONFIG_DEFAULT_FDT_FILE "\0" \
+-	"upgrade_available=1\0" \
++	"upgrade_available=0\0" \
+ 	"boot_fit=no\0" \
+ 	"mtdids="	CONFIG_MTDIDS_DEFAULT	"\0" \
+ 	"mtdparts=" CONFIG_MTDPARTS_DEFAULT "\0" \
+-- 
+2.25.1
+

--- a/layers/meta-balena-5x-owa/recipes-bsp/u-boot/u-boot-owasys.bbappend
+++ b/layers/meta-balena-5x-owa/recipes-bsp/u-boot/u-boot-owasys.bbappend
@@ -6,10 +6,13 @@ inherit resin-u-boot
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 # resin-u-boot class patch is rebased
-SRC_URI:remove = " file://resin-specific-env-integration-kconfig.patch "
+SRC_URI:remove = " file://resin-specific-env-integration-kconfig.patch \
+                   git://source.codeaurora.org/external/imx/uboot-imx.git;protocol=https;branch=${SRCBRANCH} \
+"
 
-SRC_URI:append:owa5x = " \
+SRC_URI:append:owa5x = " git://github.com/nxp-imx/uboot-imx.git;protocol=https;branch=${SRCBRANCH} \
                       file://Balena-integration-u-boot-env-configs.patch \
+                      file://0001-Fix-reboot-issue-upgrade-available-init-value-is-0.patch \
  "
 
 SRC_URI += "file://fw_env.config"

--- a/layers/meta-balena-5x-owa/recipes-kernel/linux/linux-owasys-owa5x.bbappend
+++ b/layers/meta-balena-5x-owa/recipes-kernel/linux/linux-owasys-owa5x.bbappend
@@ -2,6 +2,11 @@ LICENSE = "CLOSED"
 
 inherit kernel-resin deploy
 
+SRC_URI:remove = " git://source.codeaurora.org/external/imx/linux-imx.git;protocol=https;branch=${SRCBRANCH} "
+
+SRC_URI:append:owa5x = " git://github.com/nxp-imx/linux-imx.git;protocol=https;branch=${SRCBRANCH} \
+ "
+
 BALENA_CONFIGS:append = " nfsfs"
 BALENA_CONFIGS[nfsfs] = " \
     CONFIG_NFS_FS=m \


### PR DESCRIPTION
After 4 reboots the device halts due to upgrade_available variable set to 1 by default.

Changelog-entry: fixed reboot issue
Signed-off-by: Alvaro Guzman alvaro.guzman@owasys.com