### PR TITLE
pmsrv-service: ensure pmsrv is loaded

### DIFF
--- a/layers/meta-balena-5x-owa/recipes-core/pmsrv/files/pmsrv.service
+++ b/layers/meta-balena-5x-owa/recipes-core/pmsrv/files/pmsrv.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=pmsrv service, a service to open a socket comms with the onboard uprocessor and reset the HW watchdog.
+DefaultDependencies=no 
+
+[Service]
+ExecStart=/usr/bin/pmsrv
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+Alias=owasysd-pmsrv.service

--- a/layers/meta-balena-5x-owa/recipes-core/pmsrv/pmsrv-service_%.bbappend
+++ b/layers/meta-balena-5x-owa/recipes-core/pmsrv/pmsrv-service_%.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI += " \
+            file://pmsrv.service \
+"    


### PR DESCRIPTION
New meta-owasys layer upgrade will change the default order the power-manager service is loaded. To have it available for BalenaOS we need to ensure it is started at the very beginning of the system boot. Otherwise BalenaOS will have problems when trying to bring up both wifi and cellular interfaces as they are powered up by this pmsrv.service

Changelog-entry: power-manager is loaded properly
Signed-off-by: Alvaro Guzman <alvaro.guzman@owasys.com>

