### PR TITLE
<resin-init-board>: check lock

### DIFF
--- a/layers/meta-balena-5x-owa/recipes-support/resin-init/files/resin-init-board
+++ b/layers/meta-balena-5x-owa/recipes-support/resin-init/files/resin-init-board
@@ -2,6 +2,14 @@
 
 set -e
 
+LOCKFILE="/var/lock/owaapi.lck"                                                            
+
+sleep 10
+while [ -f "$LOCKFILE" ]
+do
+    sleep 1
+done
+
 /usr/bin/Start_BT_WiFi 1
 /usr/bin/Switch_GSM 1
 


### PR DESCRIPTION
The owa5X has an onboard uC which manages power. This uC is programmable and upgradable from the OS and it needs some time to be flashed. In order to perform a correct update when the uC firmware changes between BSP versions, we need at least 10s. A delay of 10s plus a checking on a lock has been inserted in the resin-init-board script to do the uC FW flashing.

Changelog-entry: delay to flash onboard uC FW
Signed-off-by: Alvaro Guzman <alvaro.guzman@owasys.com>