### PR TITLE
layers/meta-balena-5x-owa: Start CAN on boot

### DIFF
--- a/layers/meta-balena-5x-owa/recipes-support/resin-init/files/resin-init-board
+++ b/layers/meta-balena-5x-owa/recipes-support/resin-init/files/resin-init-board
@@ -12,5 +12,6 @@ done
 
 /usr/bin/Start_BT_WiFi 1
 /usr/bin/Switch_GSM 1
+/usr/bin/Start_CAN 1
 
 exit 0


### PR DESCRIPTION
As discussed in https://github.com/balena-os/balena-owa5x/issues/397 starting CAN communication from within balena docker applications is difficult due to needing owasys libraries in the image and needing to mount sockets to the running container. 

I suggest we enable CAN communication by default.