### PR TITLE
<99-flash-bootloader> Fix wrong bootloader name.

### DIFF
--- a/layers/meta-balena-5x-owa/recipes-support/hostapp-update-hooks/files/99-flash-bootloader
+++ b/layers/meta-balena-5x-owa/recipes-support/hostapp-update-hooks/files/99-flash-bootloader
@@ -8,7 +8,7 @@ set -o errexit
 
 # machine specific data
 
-uboot_file="owa5x-nand-flash.bin"
+uboot_file="owa5x-flash.bin"
 uboot_block_size=1024
 uboot_seek_blocks=32
 


### PR DESCRIPTION
The name of the bootloader was wrong. Now we set the same used on the resin-init-flasher service.

Changelog-entry: fixed wrong bootloader name
Signed-off-by: Alvaro Guzman <alvaro.guzman@owasys.com>"