### PR TITLE
<balena-image> Exclude pmupdate.txt from fingerprint file

### DIFF
--- a/layers/meta-balena-5x-owa/recipes-core/images/balena-image.bbappend
+++ b/layers/meta-balena-5x-owa/recipes-core/images/balena-image.bbappend
@@ -11,4 +11,4 @@ remove_files_from_fingerprint () {
      > md5sum.tmp && mv md5sum.tmp ${IMAGE_ROOTFS}/${BALENA_FINGERPRINT_FILENAME}.${BALENA_FINGERPRINT_EXT}
 }
 
-IMAGE_POSTPROCESS_COMMAND += " remove_files_from_fingerprint ; "
+IMAGE_PREPROCESS_COMMAND:append = " remove_files_from_fingerprint ; "

--- a/layers/meta-balena-5x-owa/recipes-core/images/balena-image.bbappend
+++ b/layers/meta-balena-5x-owa/recipes-core/images/balena-image.bbappend
@@ -1,1 +1,14 @@
 include balena-image.inc
+
+remove_files_from_fingerprint () {
+    # We need to exclude "pmupdate.txt" as it is only a flag-file
+    # that indicates the need to flash the onboard uC with new FW.
+    # This process is needed after every FW update, whether it is 
+    # an OTA update or an USB/uSD reflashing. After the reflashing
+    # the pmupdate is removed by pmsrv service.
+    
+    grep -v '^d41d8cd98f00b204e9800998ecf8427e  /var/lib/owasys/pmsrv/pmupdate.txt$' ${IMAGE_ROOTFS}/${BALENA_FINGERPRINT_FILENAME}.${BALENA_FINGERPRINT_EXT} \
+     > md5sum.tmp && mv md5sum.tmp ${IMAGE_ROOTFS}/${BALENA_FINGERPRINT_FILENAME}.${BALENA_FINGERPRINT_EXT}
+}
+
+IMAGE_POSTPROCESS_COMMAND += " remove_files_from_fingerprint ; "


### PR DESCRIPTION
We need to exclude pmupdate.txt as it is only a flag-file that indicates the need to flash the onboard uC with new uC FW. This process is needed after every FW update, whether it is an OTA update or an USB/uSD reflashing, and the problem is that after reflashing the uC the flag is removed by the pmsrv service. Therefore, fingerprint file contains a reference to a non-existent file, pmupdate.txt.

Changelog-entry: remove pmupdate.txt from balenaos.fingerprint
Signed-off-by: Alvaro Guzman <alvaro.guzman@owasys.com>