### PR TITLE
<owasysd-quectel-modem-setup> Improved service dependencies.

### DIFF
--- a/layers/meta-balena-5x-owa/recipes-connectivity/owasys-quectel-modem-setup/files/99-quectel-eg25g.rules
+++ b/layers/meta-balena-5x-owa/recipes-connectivity/owasys-quectel-modem-setup/files/99-quectel-eg25g.rules
@@ -1,1 +1,1 @@
-ACTION=="add", SUBSYSTEM=="tty", ENV{ID_BUS}=="usb", ENV{ID_USB_INTERFACE_NUM}=="02", ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="0125", TAG+="systemd", ENV{SYSTEMD_WANTS}="owasys-quectel-mode-setup.service"
+ACTION=="add", SUBSYSTEM=="tty", ENV{ID_BUS}=="usb", ENV{ID_USB_INTERFACE_NUM}=="03", ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="0125", TAG+="systemd", ENV{SYSTEMD_WANTS}="owasysd-quectel-modem-setup.service"

--- a/layers/meta-balena-5x-owa/recipes-connectivity/owasys-quectel-modem-setup/files/owasys-quectel-modem-setup.sh
+++ b/layers/meta-balena-5x-owa/recipes-connectivity/owasys-quectel-modem-setup/files/owasys-quectel-modem-setup.sh
@@ -10,13 +10,13 @@
 #     SUBSYSTEM=="usb", ATTR{idVendor}=="2c7c", ATTR{idProduct}=="0125"
 #
 # Modem AT port:
-#   /dev/ttyUSB2
+#   /dev/ttyUSB3
 #
 
 set -euo pipefail
 
-TTY_DEV="/dev/ttyUSB2"
-LOG_TAG="owasys-quectel-mode-setup"
+TTY_DEV="/dev/ttyUSB3"
+LOG_TAG="owasysd-quectel-modem-setup"
 
 TARGET_USBNET="1"
 
@@ -78,9 +78,7 @@ log "Set response: ${SET_RESPONSE//$'\n'/ }"
 if echo "${SET_RESPONSE}" | grep -q "OK"; then
     log "usbnet successfully changed to ${TARGET_USBNET}"
 
-    # Optional modem reset may be required on some firmware versions
-    # Uncomment if needed:
-    # send_at 'AT+CFUN=1,1'
+    send_at 'AT+CFUN=1,1'
 
     exit 0
 else

--- a/layers/meta-balena-5x-owa/recipes-connectivity/owasys-quectel-modem-setup/files/owasysd-quectel-modem-setup.service
+++ b/layers/meta-balena-5x-owa/recipes-connectivity/owasys-quectel-modem-setup/files/owasysd-quectel-modem-setup.service
@@ -1,18 +1,15 @@
 [Unit]
 Description=Configure Quectel EG25-G usbnet mode
-After=dev-ttyUSB2.device
-Requires=dev-ttyUSB2.device
+After=resin-init.service
 
 [Service]
-Type=oneshot
 ExecStartPre=sleep 2
-ExecStart=/usr/sbin/owasys-quectel-mode-setup.sh
+ExecStart=/usr/sbin/owasys-quectel-modem-setup.sh
+Restart     = on-failure
+RestartSec  = 2
 
 # Security hardening
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=true
 NoNewPrivileges=true
-
-[Install]
-WantedBy=multi-user.target

--- a/layers/meta-balena-5x-owa/recipes-connectivity/owasys-quectel-modem-setup/owasys-quectel-modem-setup_1.0.1.bb
+++ b/layers/meta-balena-5x-owa/recipes-connectivity/owasys-quectel-modem-setup/owasys-quectel-modem-setup_1.0.1.bb
@@ -13,7 +13,7 @@ SYSTEMD_SERVICE:${PN} ="owasysd-quectel-modem-setup.service"
 
 SRC_URI = " \
     file://99-quectel-eg25g.rules \
-    file://owasys-quectel-mode-setup.sh \
+    file://owasys-quectel-modem-setup.sh \
     file://owasysd-quectel-modem-setup.service \
 "
 
@@ -23,14 +23,14 @@ do_install() {
     install -d ${D}${libdir}/udev/rules.d
     install -d ${D}${sysconfdir}/systemd/system  
 
-    install -m 0755 ${WORKDIR}/owasys-quectel-mode-setup.sh ${D}${sbindir}
+    install -m 0755 ${WORKDIR}/owasys-quectel-modem-setup.sh ${D}${sbindir}
     install -m 0644 ${WORKDIR}/99-quectel-eg25g.rules ${D}${libdir}/udev/rules.d
     install -m 0644 ${WORKDIR}/owasysd-quectel-modem-setup.service ${D}${sysconfdir}/systemd/system
 
 }
 
 FILES:${PN} += " \
-    ${sbindir}/owasys-quectel-mode-setup.sh \
+    ${sbindir}/owasys-quectel-modem-setup.sh \
     ${sysconfdir}/udev/rules.d/99-quectel-eg25g.rules \
     ${sysconfdir}/systemd/owasysd-quectel-modem-setup.service \    
 "


### PR DESCRIPTION
Now service is triggered by ttyUSB3 and loads after resin-init.service

Changelog-entry: owasysd-quectel-modem-setup triggered by ttyUSB3 and loads after resin-init
Signed-off-by: Alvaro Guzman<alvaro.guzman@owasys.com>