### PR TITLE
<linux-owasys-owa5x> Disabling WIFI-DIRECT on driver.

### DIFF
--- a/layers/meta-balena-5x-owa/recipes-kernel/linux/files/0001-mwifiex-CONFIG_WIFI_DIRECT_SUPPORT-disabled.patch
+++ b/layers/meta-balena-5x-owa/recipes-kernel/linux/files/0001-mwifiex-CONFIG_WIFI_DIRECT_SUPPORT-disabled.patch
@@ -1,0 +1,27 @@
+From 30f29f2dda932a986772a599897228ee7fe8f21b Mon Sep 17 00:00:00 2001
+From: Alvaro Guzman <alvaro.guzman@owasys.com>
+Date: Thu, 11 Jun 2026 07:13:15 +0200
+Subject: [PATCH] <mwifiex> CONFIG_WIFI_DIRECT_SUPPORT disabled
+
+Changelog: Updated
+Signed-off-by: Alvaro Guzman <alvaro.guzman@owasys.com>
+---
+ drivers/net/wireless/nxp/mwifiex/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/wireless/nxp/mwifiex/Makefile b/drivers/net/wireless/nxp/mwifiex/Makefile
+index 33b185d83fca..9a681e036c4b 100644
+--- a/drivers/net/wireless/nxp/mwifiex/Makefile
++++ b/drivers/net/wireless/nxp/mwifiex/Makefile
+@@ -73,7 +73,7 @@ CONFIG_STA_SUPPORT=y
+ CONFIG_UAP_SUPPORT=y
+ 
+ # Enable WIFIDIRECT support
+-CONFIG_WIFI_DIRECT_SUPPORT=y
++CONFIG_WIFI_DIRECT_SUPPORT=n
+ 
+ 
+ # Re-association in driver
+-- 
+2.43.0
+

--- a/layers/meta-balena-5x-owa/recipes-kernel/linux/linux-owasys-owa5x_%.bbappend
+++ b/layers/meta-balena-5x-owa/recipes-kernel/linux/linux-owasys-owa5x_%.bbappend
@@ -2,6 +2,12 @@ LICENSE = "CLOSED"
 
 inherit kernel-balena deploy
 
+FILESEXTRAPATHS:append := "${THISDIR}/files:"
+
+SRC_URI += " \
+    file://0001-mwifiex-CONFIG_WIFI_DIRECT_SUPPORT-disabled.patch \
+"
+
 BALENA_CONFIGS:append = " nfsfs"
 BALENA_CONFIGS[nfsfs] = " \
     CONFIG_NFS_FS=m \


### PR DESCRIPTION
- NetworkManager was creating a device for each P2P available interface and finally fuzzing the connection process to wifi hotspots.

Changelog-entry: wifi driver recompiled without wifi direct