### PR TITLE
<owasysd-quectel-apn-injection> Automatic injection of APN using syst…

### DIFF
--- a/layers/meta-balena-5x-owa/recipes-connectivity/owasys-quectel-modem-setup/files/99-quectel-eg25g.rules
+++ b/layers/meta-balena-5x-owa/recipes-connectivity/owasys-quectel-modem-setup/files/99-quectel-eg25g.rules
@@ -1,1 +1,1 @@
-ACTION=="add", SUBSYSTEM=="tty", ENV{ID_BUS}=="usb", ENV{ID_USB_INTERFACE_NUM}=="02", ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="0125", TAG+="systemd", ENV{SYSTEMD_WANTS}="owasys-quectel-mode-setup.service"
+ACTION=="add", SUBSYSTEM=="tty", ENV{ID_BUS}=="usb", ENV{ID_USB_INTERFACE_NUM}=="03", ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="0125", TAG+="systemd", ENV{SYSTEMD_WANTS}="owasysd-quectel-ecm-modem-setup.service"

--- a/layers/meta-balena-5x-owa/recipes-connectivity/owasys-quectel-modem-setup/files/owasys-quectel-apn-injection.sh
+++ b/layers/meta-balena-5x-owa/recipes-connectivity/owasys-quectel-modem-setup/files/owasys-quectel-apn-injection.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+TAG="owasys-quectel-apn-injection"
+CONN_DIR="/etc/NetworkManager/system-connections"
+POLL_INTERVAL=2
+CID=1
+
+###############################################################################
+# Logging
+###############################################################################
+
+log() {
+    local level="$1"
+    shift
+
+    logger -t "$TAG" -p "user.$level" "$*"
+
+    printf '%s [%s] %s\n' \
+        "$(date '+%F %T')" \
+        "$level" \
+        "$*"
+}
+
+###############################################################################
+# Helpers
+###############################################################################
+
+extract_modem_id() {
+    local line="$1"
+
+    local tmp="${line##*/Modem/}"
+    printf '%s\n' "${tmp%% *}"
+}
+
+###############################################################################
+# Wait for ModemManager
+###############################################################################
+
+if ! command -v mmcli >/dev/null 2>&1; then
+    log err "mmcli not installed"
+    exit 1
+fi
+
+log info "Waiting for ModemManager service"
+
+until systemctl is-active --quiet ModemManager; do
+    sleep "$POLL_INTERVAL"
+done
+
+log info "ModemManager is active"
+
+###############################################################################
+# Wait for modem
+###############################################################################
+
+log info "Waiting for modem hotplug"
+
+while true; do
+    modem_lines=$(mmcli -L 2>/dev/null | grep "/Modem/" || true)
+
+    if [[ -n "$modem_lines" ]]; then
+        break
+    fi
+
+    sleep "$POLL_INTERVAL"
+done
+
+log notice "Detected modem(s)"
+
+###############################################################################
+# Process modems
+###############################################################################
+
+while read -r modem_line; do
+
+    [[ -z "$modem_line" ]] && continue
+
+    modem_id=$(extract_modem_id "$modem_line")
+
+    log notice "Using modem $modem_id"
+
+    ###########################################################################
+    # Wait until modem is usable
+    ###########################################################################
+
+    while true; do
+
+        modem_state=$(
+            mmcli -m "$modem_id" 2>/dev/null |
+            awk -F': ' '
+                /state/ {
+                    gsub(/^[[:space:]]+/, "", $2)
+                    print $2
+                    exit
+                }
+            '
+        )
+
+        case "$modem_state" in
+            connected|registered|enabled)
+                break
+                ;;
+        esac
+
+        sleep "$POLL_INTERVAL"
+    done
+
+    log info "Modem state is '$modem_state'"
+
+    ###########################################################################
+    # Read GSM section
+    ###########################################################################
+
+    find "$CONN_DIR" -type f | while read -r selected_file; do
+
+        APN=""
+        USERNAME=""
+        PASSWORD=""
+
+        while IFS='=' read -r key value; do
+
+            key="$(echo "$key" | xargs)"
+            value="$(echo "$value" | xargs)"
+
+            case "$key" in
+                apn)  APN="$value" ;;
+                user) USERNAME="$value" ;;
+                pass) PASSWORD="$value" ;;
+            esac
+
+        done < <(
+            awk '
+                /^\[gsm\]/ { in_gsm=1; next }
+                /^\[/      { in_gsm=0 }
+                in_gsm
+            ' "$selected_file"
+        )
+
+        if [[ -z "$APN" ]]; then
+            log err "No APN found in $selected_file"
+            continue
+        fi
+
+        log info "Processing profile: $selected_file"
+        log info "Desired APN: $APN"
+
+
+        ###########################################################################
+        # Read current modem configuration
+        ###########################################################################
+
+        current_cgdcont=$(
+            mmcli -m "$modem_id" \
+                --command='AT+CGDCONT?' \
+                2>/dev/null || true
+        )
+
+        current_apn=$(
+            printf '%s\n' "$current_cgdcont" |
+            sed -n \
+                's/.*+CGDCONT:[[:space:]]*1,"[^"]*","\([^"]*\)".*/\1/p'
+        )
+
+        current_qicsgp=$(
+            mmcli -m "$modem_id" \
+                --command="AT+QICSGP=$CID" \
+                2>/dev/null || true
+        )
+
+        ###########################################################################
+        # Skip if already configured
+        ###########################################################################
+        if [[ "$current_apn" == "$APN" ]]; then
+            log info "APN already configured ($APN), skipping"
+            continue
+        fi
+
+        ###########################################################################
+        # Configure PDP context
+        ###########################################################################
+        cgdcont_cmd="AT+CGDCONT=$CID,\"IPV4V6\",\"$APN\""
+
+        log notice "Injecting APN via CGDCONT"
+
+        mmcli -m "$modem_id" \
+            --command="$cgdcont_cmd"
+
+        ###########################################################################
+        # Configure credentials
+        ###########################################################################
+        if [[ -n "$USERNAME" || -n "$PASSWORD" ]]; then
+
+            qicsgp_cmd="AT+QICSGP=$CID,1,\"$APN\",\"$USERNAME\",\"$PASSWORD\",3"
+
+            log notice "Injecting credentials via QICSGP"
+
+            mmcli -m "$modem_id" \
+                --command="$qicsgp_cmd"
+        else
+            log info "No username/password configured"
+        fi
+
+    done
+
+    ###########################################################################
+    # Verify
+    ###########################################################################
+
+    log info "Verification"
+
+    mmcli -m "$modem_id" --command='AT+CGDCONT?' || true
+    mmcli -m "$modem_id" --command="AT+QICSGP=$CID" || true
+
+    log notice "Configuration completed"
+
+done <<< "$modem_lines"
+
+log notice "Finished"

--- a/layers/meta-balena-5x-owa/recipes-connectivity/owasys-quectel-modem-setup/files/owasys-quectel-ecm-modem-setup.sh
+++ b/layers/meta-balena-5x-owa/recipes-connectivity/owasys-quectel-modem-setup/files/owasys-quectel-ecm-modem-setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# owasys-quectel-mode-setup.sh
+# owasys-quectel-ecm-modem-setup
 #
 # Purpose:
 #   Ensure Quectel EG25-G modem is configured with usbnet=1
@@ -9,15 +9,11 @@
 #   Intended to be launched by udev when the modem appears:
 #     SUBSYSTEM=="usb", ATTR{idVendor}=="2c7c", ATTR{idProduct}=="0125"
 #
-# Modem AT port:
-#   /dev/ttyUSB2
-#
 
 set -euo pipefail
 
-TTY_DEV="/dev/ttyUSB2"
-LOG_TAG="owasys-quectel-mode-setup"
-
+LOG_TAG="owasysd-quectel-ecm-modem-setup"
+# Quectel EG25-G usdbnet 1, modem appears as an usb-ethernet adapter
 TARGET_USBNET="1"
 
 log() {
@@ -25,30 +21,34 @@ log() {
     echo "$1"
 }
 
-# Wait for tty device to become available
+# Wait for ModemManager to discover at least one modem
+MODEM_ID=""
+
 for i in {1..15}; do
-    if [[ -e "${TTY_DEV}" ]]; then
+    MODEM_ID="$(
+        mmcli -L 2>/dev/null \
+        | sed -n 's#.*/Modem/\([0-9]\+\).*#\1#p' \
+        | head -n1
+    )"
+
+    if [[ -n "${MODEM_ID}" ]]; then
         break
     fi
+
     sleep 1
 done
 
-if [[ ! -e "${TTY_DEV}" ]]; then
-    log "ERROR: ${TTY_DEV} not found"
+if [[ -z "${MODEM_ID}" ]]; then
+    log "ERROR: No modem found in ModemManager"
     exit 1
 fi
+
+log "Using modem ${MODEM_ID}"
 
 send_at() {
     local cmd="$1"
 
-    # Clear pending data
-    timeout 1 cat "${TTY_DEV}" > /dev/null 2>&1 || true
-
-    # Send command
-    printf '%s\r' "${cmd}" > "${TTY_DEV}"
-
-    # Read response
-    timeout 3 cat "${TTY_DEV}" || true
+    mmcli -m "${MODEM_ID}" --command="${cmd}" 2>/dev/null || true
 }
 
 log "Checking current usbnet mode..."
@@ -57,7 +57,11 @@ RESPONSE="$(send_at 'AT+QCFG="usbnet"')"
 
 log "Modem response: ${RESPONSE//$'\n'/ }"
 
-CURRENT_MODE="$(echo "${RESPONSE}" | sed -n 's/^.*+QCFG: "usbnet",\([0-9]\+\).*$/\1/p')"
+CURRENT_MODE="$(
+    echo "${RESPONSE}" \
+    | sed -n 's/^.*+QCFG: "usbnet",\([0-9]\+\).*$/\1/p' \
+    | head -n1
+)"
 
 if [[ -z "${CURRENT_MODE}" ]]; then
     log "ERROR: Could not determine current usbnet mode"
@@ -71,16 +75,17 @@ fi
 
 log "Changing usbnet mode from ${CURRENT_MODE} to ${TARGET_USBNET}..."
 
-SET_RESPONSE="$(send_at 'AT+QCFG="usbnet",1')"
+AT_CMD="AT+QCFG=\"usbnet\",${TARGET_USBNET}"
+SET_RESPONSE="$(send_at "${AT_CMD}")"
 
 log "Set response: ${SET_RESPONSE//$'\n'/ }"
 
 if echo "${SET_RESPONSE}" | grep -q "OK"; then
     log "usbnet successfully changed to ${TARGET_USBNET}"
 
-    # Optional modem reset may be required on some firmware versions
-    # Uncomment if needed:
-    # send_at 'AT+CFUN=1,1'
+    log "Rebooting modem..."
+
+    send_at 'AT+CFUN=1,1'
 
     exit 0
 else

--- a/layers/meta-balena-5x-owa/recipes-connectivity/owasys-quectel-modem-setup/files/owasysd-quectel-apn-injection.service
+++ b/layers/meta-balena-5x-owa/recipes-connectivity/owasys-quectel-modem-setup/files/owasysd-quectel-apn-injection.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Inject existing APN in system-connections to EG25-G modem
+After=owasysd-quectel-ecm-modem-setup.service
+Requires=ModemManager.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/owasys-quectel-apn-injection.sh
+
+# Security hardening
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+NoNewPrivileges=true
+
+# In case if it gets stopped, restart it immediately
+Restart     = on-failure
+RestartSec  = 30
+
+[Install]
+WantedBy=multi-user.target

--- a/layers/meta-balena-5x-owa/recipes-connectivity/owasys-quectel-modem-setup/files/owasysd-quectel-ecm-modem-setup.service
+++ b/layers/meta-balena-5x-owa/recipes-connectivity/owasys-quectel-modem-setup/files/owasysd-quectel-ecm-modem-setup.service
@@ -1,18 +1,16 @@
 [Unit]
 Description=Configure Quectel EG25-G usbnet mode
-After=dev-ttyUSB2.device
-Requires=dev-ttyUSB2.device
+After=resin-init.service
+Requires=ModemManager.service
 
 [Service]
-Type=oneshot
 ExecStartPre=sleep 2
-ExecStart=/usr/sbin/owasys-quectel-mode-setup.sh
+ExecStart=/usr/sbin/owasys-quectel-ecm-modem-setup.sh
+Restart     = on-failure
+RestartSec  = 2
 
 # Security hardening
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=true
 NoNewPrivileges=true
-
-[Install]
-WantedBy=multi-user.target

--- a/layers/meta-balena-5x-owa/recipes-connectivity/owasys-quectel-modem-setup/owasys-quectel-apn-injection_1.0.0.bb
+++ b/layers/meta-balena-5x-owa/recipes-connectivity/owasys-quectel-modem-setup/owasys-quectel-apn-injection_1.0.0.bb
@@ -1,0 +1,31 @@
+SUMMARY = " Owasys service to parse nmconnection file and mmcli inject APN into the modem."
+LICENSE = "Proprietary"
+LIC_FILES_CHKSUM ="file://${COMPANY_CUSTOM_LICENSES}/copyright;md5=d9808d05a6f4f9e517af468c7f14a160"
+inherit systemd
+
+RDEPENDS:${PN} += " \
+    bash \
+"
+
+SYSTEMD_AUTO_ENABLE = "enable"
+SYSTEMD_SERVICE:${PN} = "owasysd-quectel-apn-injection.service"
+
+SRC_URI = " \
+    file://owasys-quectel-apn-injection.sh \
+    file://owasysd-quectel-apn-injection.service \
+"
+
+do_install() {
+  
+    install -d ${D}${sbindir}
+    install -d ${D}${sysconfdir}/systemd/system
+
+    install -m 0755 ${WORKDIR}/owasys-quectel-apn-injection.sh ${D}${sbindir}
+    install -m 0644 ${WORKDIR}/owasysd-quectel-apn-injection.service ${D}${sysconfdir}/systemd/system
+
+}
+
+FILES:${PN} += " \
+    ${sbindir}/owasys-quectel-apn-injection.sh \
+    ${sysconfdir}/systemd/owasysd-quectel-apn-injection.service \
+"

--- a/layers/meta-balena-5x-owa/recipes-connectivity/owasys-quectel-modem-setup/owasys-quectel-ecm-modem-setup_1.0.0.bb
+++ b/layers/meta-balena-5x-owa/recipes-connectivity/owasys-quectel-modem-setup/owasys-quectel-ecm-modem-setup_1.0.0.bb
@@ -9,12 +9,12 @@ RDEPENDS:${PN} += " \
 "
 
 SYSTEMD_AUTO_ENABLE = "enable"
-SYSTEMD_SERVICE:${PN} ="owasysd-quectel-modem-setup.service"
+SYSTEMD_SERVICE:${PN} ="owasysd-quectel-ecm-modem-setup.service"
 
 SRC_URI = " \
     file://99-quectel-eg25g.rules \
-    file://owasys-quectel-mode-setup.sh \
-    file://owasysd-quectel-modem-setup.service \
+    file://owasys-quectel-ecm-modem-setup.sh \
+    file://owasysd-quectel-ecm-modem-setup.service \
 "
 
 do_install() {
@@ -23,14 +23,14 @@ do_install() {
     install -d ${D}${libdir}/udev/rules.d
     install -d ${D}${sysconfdir}/systemd/system  
 
-    install -m 0755 ${WORKDIR}/owasys-quectel-mode-setup.sh ${D}${sbindir}
+    install -m 0755 ${WORKDIR}/owasys-quectel-ecm-modem-setup.sh ${D}${sbindir}
     install -m 0644 ${WORKDIR}/99-quectel-eg25g.rules ${D}${libdir}/udev/rules.d
-    install -m 0644 ${WORKDIR}/owasysd-quectel-modem-setup.service ${D}${sysconfdir}/systemd/system
+    install -m 0644 ${WORKDIR}/owasysd-quectel-ecm-modem-setup.service ${D}${sysconfdir}/systemd/system
 
 }
 
 FILES:${PN} += " \
-    ${sbindir}/owasys-quectel-mode-setup.sh \
+    ${sbindir}/owasys-quectel-ecm-modem-setup.sh \
     ${sysconfdir}/udev/rules.d/99-quectel-eg25g.rules \
-    ${sysconfdir}/systemd/owasysd-quectel-modem-setup.service \    
+    ${sysconfdir}/systemd/owasysd-quectel-ecm-modem-setup.service \    
 "

--- a/layers/meta-balena-5x-owa/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-5x-owa/recipes-core/images/balena-image.inc
@@ -58,7 +58,8 @@ IMAGE_INSTALL:append = " \
                         owasys-pollux-cli \
                         owasys-pollux-device \
                         owasys-pollux-can \
-                        owasys-quectel-modem-setup \
+                        owasys-quectel-apn-injection \
+                        owasys-quectel-ecm-modem-setup \
 "
 
 deltask do_packagedata


### PR DESCRIPTION
…emd service

We include a service triggered after the modem is set in ECM mode, which parses the network profiles on /etc/NetworkManager/system-connection and inject the APN into the modem using mmcli.

Changelog-entry: APN injection vis systemd service