### PR TITLE
networkmanager_%.bbappend: Do not manage uap* interfaces

### DIFF
--- a/layers/meta-balena-5x-owa/recipes-connectivity/networkmanager/networkmanager/99-unmanaged-uap-devices.conf
+++ b/layers/meta-balena-5x-owa/recipes-connectivity/networkmanager/networkmanager/99-unmanaged-uap-devices.conf
@@ -1,0 +1,3 @@
+[device-unmanaged-uap-interfaces]
+match-device=interface-name:uap0;interface-name:uap1
+managed=0

--- a/layers/meta-balena-5x-owa/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/layers/meta-balena-5x-owa/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -1,0 +1,9 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append = " \
+        file://99-unmanaged-uap-devices.conf \
+"
+
+do_install:append() {
+    install -m 0644 ${WORKDIR}/99-unmanaged-uap-devices.conf ${D}${sysconfdir}/NetworkManager/conf.d/
+}


### PR DESCRIPTION
NM will try to connect to APs using these interfaces and will fail. Let's not manage them so that NM will use the correct mlan0 interface.

Changelog-entry: Make NetworkManager not manage uap interfaces