### PR TITLE
<pmsrv> Removed pmupdate.txt

### DIFF
--- a/layers/meta-balena-5x-owa/recipes-core/images/balena-image.bbappend
+++ b/layers/meta-balena-5x-owa/recipes-core/images/balena-image.bbappend
@@ -1,14 +1,1 @@
 include balena-image.inc
-
-remove_files_from_fingerprint () {
-    # We need to exclude "pmupdate.txt" as it is only a flag-file
-    # that indicates the need to flash the onboard uC with new FW.
-    # This process is needed after every FW update, whether it is 
-    # an OTA update or an USB/uSD reflashing. After the reflashing
-    # the pmupdate is removed by pmsrv service.
-    
-    grep -v '^d41d8cd98f00b204e9800998ecf8427e  /var/lib/owasys/pmsrv/pmupdate.txt$' ${IMAGE_ROOTFS}/${BALENA_FINGERPRINT_FILENAME}.${BALENA_FINGERPRINT_EXT} \
-     > md5sum.tmp && mv md5sum.tmp ${IMAGE_ROOTFS}/${BALENA_FINGERPRINT_FILENAME}.${BALENA_FINGERPRINT_EXT}
-}
-
-IMAGE_PREPROCESS_COMMAND:append = " remove_files_from_fingerprint ; "

--- a/layers/meta-balena-5x-owa/recipes-core/pmsrv/pmsrv_%.bbappend
+++ b/layers/meta-balena-5x-owa/recipes-core/pmsrv/pmsrv_%.bbappend
@@ -1,3 +1,10 @@
 FILESEXTRAPATHS:append := ":${THISDIR}/files"
 
 SRC_URI:append = " file://do_not_set_hostname.patch"
+
+
+do_install:append() {
+
+    rm ${D}${localstatedir}/lib/owasys/pmsrv/pmupdate.txt
+
+}


### PR DESCRIPTION
That file was previously added as a flag to reflash internal uC FW. Now, that reflashing is automatically handled by pmsrv, thus making uneeded the file. Futhermore, its presence in a RO FS, was forcing a reflashing of the uC on every power on.

Changelog-entry: removed pmupdate.txt