### PR TITLE
<u-boot> Migrate dtb from boot partition to rootfs

### DIFF
--- a/layers/meta-balena-5x-owa/recipes-bsp/u-boot/files/0002-Balena-fdt-partition-migration.patch
+++ b/layers/meta-balena-5x-owa/recipes-bsp/u-boot/files/0002-Balena-fdt-partition-migration.patch
@@ -1,0 +1,23 @@
+diff --git a/include/configs/imx8mp_owa5x.h b/include/configs/imx8mp_owa5x.h
+index 8c6c263f42..e429636862 100644
+--- a/include/configs/imx8mp_owa5x.h
++++ b/include/configs/imx8mp_owa5x.h
+@@ -213,7 +213,17 @@
+ 		"setenv mmcdev ${resin_dev_index};" \
+ 		"setenv mmcbootpart ${resin_root_part};\0" \
+ 	"balena_load_kernel=ext4load mmc ${mmcdev}:${resin_root_part} ${zip_addr} boot/${image}\0 " \
+-	"balena_load_fdt=fatload mmc ${mmcdev}:${resin_boot_part} ${fdt_addr} ${fdt_file}\0 " \
++    "balena_load_fdt=" \
++           "if ext4load mmc ${mmcdev}:${resin_root_part} ${fdt_addr} boot/${fdt_file}; then " \
++                   "echo Loaded ${fdt_file} from mmc ${mmcdev}:${resin_root_part}; " \
++           "else " \
++                   "echo Failed to load ${fdt_file} from mmc ${mmcdev}:${resin_root_part}; " \
++                   "if fatload mmc ${mmcdev}:${resin_boot_part} ${fdt_addr} ${fdt_file}; then " \
++                           "echo Loaded ${fdt_file} from mmc ${mmcdev}:${resin_boot_part}; " \
++                   "else " \
++                           "echo Failed to load ${fdt_file} from mmc ${mmcdev}:${resin_boot_part}; " \
++                   "fi;" \
++           "fi;\0" \
+ 	"BOOT_CMD_BALENA=run set_up_balena_env_vars; " \
+ 		"run mmcargs; " \ 
+ 		"run balena_load_kernel; " \

--- a/layers/meta-balena-5x-owa/recipes-bsp/u-boot/u-boot-owasys_%.bbappend
+++ b/layers/meta-balena-5x-owa/recipes-bsp/u-boot/u-boot-owasys_%.bbappend
@@ -10,6 +10,7 @@ SRC_URI:remove = " file://resin-specific-env-integration-kconfig.patch "
 
 SRC_URI:append:owa5x-nand = " \
                       file://0001-Balena-integration-u-boot-2.1.6.patch \
+                      file://0002-Balena-fdt-partition-migration.patch \
 "
 
 SRC_URI += "file://fw_env.config"

--- a/layers/meta-balena-5x-owa/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-5x-owa/recipes-core/images/balena-image.inc
@@ -4,7 +4,6 @@ DEVICE_TYPE = "owa5x"
 
 BALENA_BOOT_PARTITION_FILES:owa5x += " \
      ${MACHINE}-flash.bin:/${MACHINE}-flash.bin \
-     imx8mp-owa5x.dtb:/imx8mp-owa5x.dtb \
 "
 
 IMAGE_CMD:balenaos-img:append () {
@@ -60,6 +59,7 @@ IMAGE_INSTALL:append = " \
                         owasys-pollux-can \
                         owasys-quectel-apn-injection \
                         owasys-quectel-ecm-modem-setup \
+                        kernel-devicetree \
 "
 
 deltask do_packagedata

--- a/layers/meta-balena-5x-owa/recipes-support/hostapp-update-hooks/files/99-flash-bootloader
+++ b/layers/meta-balena-5x-owa/recipes-support/hostapp-update-hooks/files/99-flash-bootloader
@@ -37,5 +37,6 @@ for i in $update_files; do
                 dd if=/resin-boot/$current_update_file of=$device conv=fdatasync seek=$seek_blocks bs=$block_size
 		echo 1 > /sys/block/mmcblk2boot0/force_ro
         fi
+        kobs-ng init -v --chip_0_device_path=/dev/mtd0 /resin-boot/owa5x-flash.bin
 done
 


### PR DESCRIPTION
Now the dtb is located at the rootfs partition, under the boot folder.
This enables dtb redundancy.
For backward compatibility purposes, if the u-boot is unable to load the
dtb from the rootfs partition it will also check the boot partition.

This fixes the rollback in the case of a failed update.

Changelog-entry: Load device tree from the root partition
Signed-off-by: Aitor Nieto [aitor.nieto@owasys.com](mailto:aitor.nieto@owasys.com)