### PR TITLE
<NetworkManager> Fix route-metric for Quectel Modem

### DIFF
--- a/layers/meta-balena-5x-owa/recipes-connectivity/networkmanager/networkmanager/zz-networkmanager.conf
+++ b/layers/meta-balena-5x-owa/recipes-connectivity/networkmanager/networkmanager/zz-networkmanager.conf
@@ -1,0 +1,4 @@
+[connection-modem-cdc]
+match-device=driver:cdc_ether
+ipv4.route-metric=700
+ipv6.route-metric=700

--- a/layers/meta-balena-5x-owa/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/layers/meta-balena-5x-owa/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -2,8 +2,13 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI:append = " \
         file://99-unmanaged-uap-devices.conf \
+        file://zz-networkmanager.conf \
 "
 
 do_install:append() {
-    install -m 0644 ${WORKDIR}/99-unmanaged-uap-devices.conf ${D}${sysconfdir}/NetworkManager/conf.d/
+    install -d ${D}${libdir}/NetworkManager/conf.d
+    install -m 0644 \
+        ${WORKDIR}/zz-networkmanager.conf \
+        ${D}${libdir}/NetworkManager/conf.d/zz-networkmanager.conf
+    install -m 0644 ${WORKDIR}/99-unmanaged-uap-devices.conf ${D}${libdir}/NetworkManager/conf.d/
 }


### PR DESCRIPTION
- Increase the route metric by 700 for the Quectel USB Ethernet interface to prevent the OWA from getting stuck without internet connectivity when NetworkManager incorrectly prefers the modem interface if no SIM card is present or the modem has no internet access, despite another interface providing a working internet connection.

- Move 99-unmanaged-uap-devices.conf to /lib, it was being overwritten by the bind mount in /etc

Changelog-entry: Fix route-metric for Quectel Modem
Signed-off-by: Aitor Nieto <aitor.nieto@owasys.com>