### PR TITLE
<balena-image-flasher> Add dtb to boot partition on image flasher

### DIFF
--- a/layers/meta-balena-5x-owa/recipes-core/images/balena-image-flasher.bbappend
+++ b/layers/meta-balena-5x-owa/recipes-core/images/balena-image-flasher.bbappend
@@ -1,6 +1,6 @@
 include balena-image.inc
 
-BALENA_BOOT_PARTITION_FILES = " \
+BALENA_BOOT_PARTITION_FILES:owa5x = " \
      ${KERNEL_IMAGETYPE}${KERNEL_INITRAMFS}-${MACHINE}.bin:/Image.gz \
      imx8mp-owa5x.dtb:/imx8mp-owa5x.dtb \
      ${MACHINE}-flash.bin:/${MACHINE}-flash.bin \


### PR DESCRIPTION
Add dtb to boot partition on image flasher while leaving removed on the balenaos image

Changelog-entry: Fix dtb missing on boot partition balena-image-flasher